### PR TITLE
[Feat] Redis 기반 JWT 자동 재발급 및 쿠키 인증 필터 구현

### DIFF
--- a/BE/src/main/java/com/oss/maeumnaru/global/config/SecurityConfig.java
+++ b/BE/src/main/java/com/oss/maeumnaru/global/config/SecurityConfig.java
@@ -1,16 +1,27 @@
 package com.oss.maeumnaru.global.config;
 
+import com.oss.maeumnaru.global.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.List;
+
+@RequiredArgsConstructor
 @Configuration
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -25,16 +36,31 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable()) //
+                .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/", "/index", "/error",
-                                "/api/user/**",
+                                "/api/user/**",               // 회원가입, 로그인 API
                                 "/favicon.ico", "/css/**", "/js/**", "/images/**"
                         ).permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);  // 필터 추가
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);  // 쿠키 허용
+        config.setAllowedOriginPatterns(List.of("http://localhost:3000"));  // 프론트 주소 허용
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/BE/src/main/java/com/oss/maeumnaru/global/jwt/JwtAuthenticationFilter.java
+++ b/BE/src/main/java/com/oss/maeumnaru/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+// JwtAuthenticationFilter.java
+package com.oss.maeumnaru.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        log.debug("JwtAuthenticationFilter: doFilterInternal 시작");
+
+        Optional<Cookie> accessTokenCookie = getCookie(request, "accessToken");
+
+        if (accessTokenCookie.isPresent()) {
+            String accessToken = accessTokenCookie.get().getValue();
+            boolean valid = jwtTokenProvider.validateToken(accessToken, response);
+
+            UsernamePasswordAuthenticationToken authentication;
+
+            if (valid) {
+                authentication = jwtTokenProvider.createAuthenticationFromToken(accessToken, null);
+            } else {
+                authentication = jwtTokenProvider.replaceAccessToken(response, accessToken);
+            }
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return Optional.empty();
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(name))
+                .findFirst();
+    }
+}

--- a/BE/src/main/java/com/oss/maeumnaru/global/util/CookieUtils.java
+++ b/BE/src/main/java/com/oss/maeumnaru/global/util/CookieUtils.java
@@ -1,0 +1,18 @@
+package com.oss.maeumnaru.global.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.Optional;
+
+public class CookieUtils {
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            return Arrays.stream(cookies)
+                    .filter(cookie -> name.equals(cookie.getName()))
+                    .findFirst();
+        }
+        return Optional.empty();
+    }
+}

--- a/BE/src/main/java/com/oss/maeumnaru/user/controller/UserController.java
+++ b/BE/src/main/java/com/oss/maeumnaru/user/controller/UserController.java
@@ -25,8 +25,8 @@ public class UserController {
 
     // 로그인
     @PostMapping("/login")
-    public ResponseEntity<TokenResponseDTO> login(@RequestBody @Valid LoginRequestDTO dto) {
-        TokenResponseDTO token = userService.login(dto);
+    public ResponseEntity<TokenResponseDTO> login(@RequestBody @Valid LoginRequestDTO dto, HttpServletResponse response) {
+        TokenResponseDTO token = userService.login(dto, response);
         return ResponseEntity.ok(token);
     }
 }


### PR DESCRIPTION
1. AccessToken 자동 재발급 로직 구현
accessToken 만료 시, Redis에 저장된 refreshToken으로 자동 재발급
재발급된 accessToken을 쿠키로 다시 저장
JwtTokenProvider.replaceAccessToken()에서 처리

2. JwtAuthenticationFilter 개선
OncePerRequestFilter로 변경 → Spring Security 표준 필터 적용
모든 요청 시 쿠키에서 accessToken 추출 → 유효성 확인 → 인증 처리
accessToken이 만료된 경우 → Redis에서 refreshToken 조회 후 자동 재발급

3. 쿠키 기반 인증 흐름 완료
로그인 성공 시 accessToken을 HttpOnly 쿠키에 저장 (JwtTokenProvider.saveCookie)
SecurityContextHolder에 인증정보 저장

4. CORS 설정 변경 (React 연동 대응)
config.setAllowCredentials(true)
config.setAllowedOriginPatterns(List.of("http://localhost:3000"))
