### PR TITLE
Feat/#4 paint 및 medical 수정

### DIFF
--- a/BE/src/main/java/com/oss/maeumnaru/medical/dto/MedicalResponseDto.java
+++ b/BE/src/main/java/com/oss/maeumnaru/medical/dto/MedicalResponseDto.java
@@ -8,6 +8,7 @@ import java.util.Date;
 @Data
 @Builder
 public class MedicalResponseDto {
+    private Long medicId;
 
     private String patientCode;
     private String patientName;

--- a/BE/src/main/java/com/oss/maeumnaru/medical/service/MedicalService.java
+++ b/BE/src/main/java/com/oss/maeumnaru/medical/service/MedicalService.java
@@ -37,6 +37,7 @@ public class MedicalService {
                 .map(medical -> {
                     PatientEntity patient = medical.getPatient();
                     return MedicalResponseDto.builder()
+                            .medicId(medical.getMedicId())
                             .patientCode(patient.getPatientCode())
                             .patientName(patient.getMember().getName())
                             .patientBirthDate(patient.getMember().getBirthDate().toString())

--- a/BE/src/main/java/com/oss/maeumnaru/paint/entity/ChatEntity.java
+++ b/BE/src/main/java/com/oss/maeumnaru/paint/entity/ChatEntity.java
@@ -3,6 +3,7 @@ package com.oss.maeumnaru.paint.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import com.oss.maeumnaru.paint.entity.PaintEntity;
+
 import java.util.Date;
 
 @Entity

--- a/BE/src/main/java/com/oss/maeumnaru/paint/service/PaintService.java
+++ b/BE/src/main/java/com/oss/maeumnaru/paint/service/PaintService.java
@@ -46,6 +46,12 @@ public class PaintService {
         return paint.map(PaintResponseDto::fromEntity);
     }
 
+    public PaintEntity getPaintEntityById(Long paintId) {
+        return paintRepository.findById(paintId)
+                .orElseThrow(() -> new ApiException(ExceptionEnum.PAINT_NOT_FOUND));
+    }
+
+
     public PaintResponseDto savePaintDraft(String patientCode, MultipartFile file, PaintRequestDto dto) throws IOException {
         try {
             // S3에 파일 업로드


### PR DESCRIPTION
## 변경 사항
- PaintController에서 사용자의 토큰(memberId)을 활용하여 환자코드를 조회함으로써 
   인증된 사용자만 자신의 환자 데이터에 접근할 수 있도록 안전성을 확보
- finalizePaint()에서 덮어쓰기 방식 사용 확인
- MedicalResponseDto에 medicId 필드 추가
- MedicalService에서 getPatientsByDoctor()에 medicId 포함


## 기타 참고 사항
- 추후 프론트엔드에서 medicId 활용 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 진료 기록 응답에 medicId(진료 기록 식별자) 필드가 추가되었습니다.
- **버그 수정**
	- 모든 그림(PAINT) 관련 기능에서 본인 소유 여부가 검증되어, 본인만 접근 및 수정이 가능하도록 개선되었습니다.
- **리팩터**
	- 그림(PAINT) 관련 엔드포인트에서 환자 코드 입력을 제거하고, 인증된 사용자 정보를 기반으로 환자 코드가 자동 처리됩니다.
	- 엔드포인트의 경로 변수명이 일관되게 `{paintId}`로 변경되었습니다.
- **스타일**
	- 코드 내 불필요한 공백이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->