### PR TITLE
feat:7일치 분석을 resultDate기준-> createDate기준으로 변경

### DIFF
--- a/BE/src/main/java/com/oss/maeumnaru/diary/repository/DiaryAnalysisRepository.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/repository/DiaryAnalysisRepository.java
@@ -14,4 +14,7 @@ public interface DiaryAnalysisRepository extends JpaRepository<DiaryAnalysisEnti
     Optional<DiaryAnalysisEntity> findByDiary_DiaryId(Long diaryId);
 
     List<DiaryAnalysisEntity> findByDiary_Patient_PatientCodeAndResultDateBetweenOrderByResultDateAsc(String patientCode, Date startDate, Date endDate);
+
+    List<DiaryAnalysisEntity> findByDiary_Patient_PatientCodeAndDiary_CreateDateBetweenOrderByDiary_CreateDateAsc(
+            String patientCode, Date startDate, Date endDate);
 }

--- a/BE/src/main/java/com/oss/maeumnaru/diary/service/DiaryAnalysisService.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/service/DiaryAnalysisService.java
@@ -80,8 +80,10 @@ public class DiaryAnalysisService {
             Date startDate = new Date(baseDate.getTime() - MILLIS_IN_DAY * 6);
             Date endDate = new Date(baseDate.getTime() + MILLIS_IN_DAY - 1);
 
-            return diaryAnalysisRepository.findByDiary_Patient_PatientCodeAndResultDateBetweenOrderByResultDateAsc(
-                    patientCode, startDate, endDate);
+            return diaryAnalysisRepository
+                    .findByDiary_Patient_PatientCodeAndDiary_CreateDateBetweenOrderByDiary_CreateDateAsc(
+                            patientCode, startDate, endDate
+                    );
         } catch (DataAccessException e) {
             throw new ApiException(ExceptionEnum.DATABASE_ERROR);
         } catch (Exception e) {


### PR DESCRIPTION
최종저장을 했을 때의 일자 기준을 달력의 날짜(createDate)로 변경하여 중복되어 일주일치가 잘못 불러와지는 오류를 고침

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 주간 분석 내역 조회 시, 분석 결과 날짜가 아닌 일기 작성일 기준으로 결과가 정렬되고 필터링되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->