### PR TITLE
fix:createDate를 Date->String(타임존 에러)

### DIFF
--- a/BE/src/main/java/com/oss/maeumnaru/diary/controller/DiaryAnalysisController.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/controller/DiaryAnalysisController.java
@@ -37,7 +37,7 @@ public class DiaryAnalysisController {
 
     @GetMapping("/weekly")
     public ResponseEntity<List<DiaryAnalysisResponseDto>> getWeeklyAnalysesByMemberId(
-            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") Date baseDate,
+            @RequestParam String baseDate,
             @RequestParam String patientCode) {
 
         List<DiaryAnalysisResponseDto> response = diaryAnalysisService.findWeeklyAnalysesByPatientCode(patientCode, baseDate)
@@ -47,6 +47,7 @@ public class DiaryAnalysisController {
 
         return ResponseEntity.ok(response);
     }
+
     // 단일 일기 분석 결과 조회
     @GetMapping("/{diaryId}")
     public ResponseEntity<DiaryAnalysisResponseDto> getAnalysisByDiaryId(@PathVariable Long diaryId) {

--- a/BE/src/main/java/com/oss/maeumnaru/diary/controller/DiaryController.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/controller/DiaryController.java
@@ -79,7 +79,7 @@ public class DiaryController {
     @GetMapping("/by-date")
     public ResponseEntity<Optional<DiaryResponseDto>> getDiariesByMemberIdAndDate(
             Authentication authentication,
-            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") Date date) {
+            @RequestParam String date) {
 
         CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
         Long memberId = principal.getMemberId();

--- a/BE/src/main/java/com/oss/maeumnaru/diary/controller/EmotionController.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/controller/EmotionController.java
@@ -16,23 +16,21 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/diary")
 @RequiredArgsConstructor
-public class emotionController {
+public class EmotionController {
 
-    private final EmotionService emotionService;
-    private final MemberRepository memberRepository;
+    private final EmotionService EmotionService;
+    private final MemberRepository MemberRepository;
 
     @GetMapping("/mainpage")
     public ResponseEntity<List<DiaryResponseDto>> getDiariesByMonthAndYear(
             Authentication authentication,
-            @RequestParam int year,
-            @RequestParam int month) {
+            @RequestParam String year,
+            @RequestParam String month) {
 
-        // 1️⃣ 로그인 사용자 확인
         String loginId = authentication.getName();
-        MemberEntity member = memberRepository.findByLoginId(loginId)
+        MemberEntity member = MemberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new ApiException(ExceptionEnum.MEMBER_NOT_FOUND));
 
-        // 2️⃣ 환자 코드 조회
         String patientCode = member.getPatient() != null
                 ? member.getPatient().getPatientCode()
                 : null;
@@ -41,8 +39,7 @@ public class emotionController {
             throw new ApiException(ExceptionEnum.PATIENT_NOT_FOUND);
         }
 
-        // 3️⃣ EmotionService 호출
-        List<DiaryResponseDto> diaries = emotionService.getDiariesByPatientCodeAndMonth(patientCode, year, month);
+        List<DiaryResponseDto> diaries = EmotionService.getDiariesByPatientCodeAndMonth(patientCode, year, month);
 
         return ResponseEntity.ok(diaries);
     }

--- a/BE/src/main/java/com/oss/maeumnaru/diary/dto/DiaryRequestDto.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/dto/DiaryRequestDto.java
@@ -16,9 +16,8 @@ import java.util.Date;
 public class DiaryRequestDto {
 
     private String title;
-    @DateTimeFormat(pattern = "yyyy-MM-dd")  // form-data 요청 대응용
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") // JSON 요청 대응용
-    private Date createDate;
+
+    private String createDate;
     // createDate, updateDate, patientCode 는 서버에서 처리하므로 제거
 }
 

--- a/BE/src/main/java/com/oss/maeumnaru/diary/dto/DiaryResponseDto.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/dto/DiaryResponseDto.java
@@ -15,7 +15,7 @@ public class DiaryResponseDto {
     private Long diaryId;
     private String contentPath;
     private String title;
-    private Date createDate;
+    private String createDate;
     private Date updateDate;
     private String patientCode;
 

--- a/BE/src/main/java/com/oss/maeumnaru/diary/entity/DiaryEntity.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/entity/DiaryEntity.java
@@ -22,8 +22,7 @@ public class DiaryEntity {
 
     private String title;
 
-    @Temporal(TemporalType.DATE)
-    private Date createDate;
+    private String createDate;
 
     @Temporal(TemporalType.TIMESTAMP)
     private Date updateDate;

--- a/BE/src/main/java/com/oss/maeumnaru/diary/repository/DiaryAnalysisRepository.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/repository/DiaryAnalysisRepository.java
@@ -13,8 +13,9 @@ public interface DiaryAnalysisRepository extends JpaRepository<DiaryAnalysisEnti
 
     Optional<DiaryAnalysisEntity> findByDiary_DiaryId(Long diaryId);
 
-    List<DiaryAnalysisEntity> findByDiary_Patient_PatientCodeAndResultDateBetweenOrderByResultDateAsc(String patientCode, Date startDate, Date endDate);
+    List<DiaryAnalysisEntity> findByDiary_Patient_PatientCodeAndResultDateBetweenOrderByResultDateAsc(
+            String patientCode, String startDate, String endDate);
 
     List<DiaryAnalysisEntity> findByDiary_Patient_PatientCodeAndDiary_CreateDateBetweenOrderByDiary_CreateDateAsc(
-            String patientCode, Date startDate, Date endDate);
+            String patientCode, String startDate, String endDate);
 }

--- a/BE/src/main/java/com/oss/maeumnaru/diary/repository/DiaryRepository.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/repository/DiaryRepository.java
@@ -13,16 +13,20 @@ import java.util.Optional;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
-    Optional<DiaryEntity> findByPatient_PatientCodeAndCreateDate(String patientCode, Date date);
 
-    List<DiaryEntity> findByPatient_PatientCodeAndCreateDateBetween(String patientCode, Date startDate, Date endDate);
+    // patientCode와 createDate를 기준으로 단일 조회
+    Optional<DiaryEntity> findByPatient_PatientCodeAndCreateDate(String patientCode, String createDate);
+
+    // patientCode와 createDate 범위로 조회
+    List<DiaryEntity> findByPatient_PatientCodeAndCreateDateBetween(String patientCode, String startDate, String endDate);
+
     // 연-월 조회용 JPQL
     @Query("SELECT d FROM DiaryEntity d " +
             "WHERE d.patient.patientCode = :patientCode " +
-            "AND FUNCTION('YEAR', d.createDate) = :year " +
-            "AND FUNCTION('MONTH', d.createDate) = :month")
+            "AND SUBSTRING(d.createDate, 1, 4) = :year " +
+            "AND SUBSTRING(d.createDate, 6, 2) = :month")
     List<DiaryEntity> findByPatient_PatientCodeAndYearAndMonth(
             @Param("patientCode") String patientCode,
-            @Param("year") int year,
-            @Param("month") int month);
+            @Param("year") String year,
+            @Param("month") String month);
 }

--- a/BE/src/main/java/com/oss/maeumnaru/diary/service/DiaryAnalysisService.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/service/DiaryAnalysisService.java
@@ -74,18 +74,17 @@ public class DiaryAnalysisService {
     }
 
     // 최근 7일간 분석 결과 조회
-    public List<DiaryAnalysisEntity> findWeeklyAnalysesByPatientCode(String patientCode, Date baseDate) {
+    public List<DiaryAnalysisEntity> findWeeklyAnalysesByPatientCode(String patientCode, String baseDate) {
         try {
-            long MILLIS_IN_DAY = 24 * 60 * 60 * 1000L;
-            Date startDate = new Date(baseDate.getTime() - MILLIS_IN_DAY * 6);
-            Date endDate = new Date(baseDate.getTime() + MILLIS_IN_DAY - 1);
+
+            LocalDate base = LocalDate.parse(baseDate); // Java 8+
+
+            String startDate = base.minusDays(6).toString();  // yyyy-MM-dd
+            String endDate = base.toString();                 // yyyy-MM-dd
 
             return diaryAnalysisRepository
                     .findByDiary_Patient_PatientCodeAndDiary_CreateDateBetweenOrderByDiary_CreateDateAsc(
-                            patientCode, startDate, endDate
-                    );
-        } catch (DataAccessException e) {
-            throw new ApiException(ExceptionEnum.DATABASE_ERROR);
+                            patientCode, startDate, endDate);
         } catch (Exception e) {
             throw new ApiException(ExceptionEnum.SERVER_ERROR);
         }

--- a/BE/src/main/java/com/oss/maeumnaru/diary/service/DiaryService.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/service/DiaryService.java
@@ -115,13 +115,16 @@ public class DiaryService {
         }
     }
 
-    public Optional<DiaryResponseDto> getDiaryByPatientCodeAndDate(String patientCode, Date date) {
+    public Optional<DiaryResponseDto> getDiaryByPatientCodeAndDate(String patientCode, String date) {
         try {
             Optional<DiaryEntity> diary = diaryRepository.findByPatient_PatientCodeAndCreateDate(patientCode, date);
             return diary.map(DiaryResponseDto::fromEntity);
         } catch (DataAccessException e) {
             log.error("getDiaryByPatientCodeAndDate DatabaseException", e);
-            throw new ApiException (ExceptionEnum.DATABASE_ERROR);
+            throw new ApiException(ExceptionEnum.DATABASE_ERROR);
+        } catch (Exception e) {
+            log.error("getDiaryByPatientCodeAndDate UnknownException", e);
+            throw new ApiException(ExceptionEnum.SERVER_ERROR);
         }
     }
 }

--- a/BE/src/main/java/com/oss/maeumnaru/diary/service/EmotionService.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/service/EmotionService.java
@@ -18,7 +18,8 @@ public class EmotionService {
 
     private final DiaryRepository diaryRepository;
 
-    public List<DiaryResponseDto> getDiariesByPatientCodeAndMonth(String patientCode, int year, int month) {
+    // 연-월 조회만 사용
+    public List<DiaryResponseDto> getDiariesByPatientCodeAndMonth(String patientCode, String year, String month) {
         try {
             List<DiaryEntity> diaries = diaryRepository
                     .findByPatient_PatientCodeAndYearAndMonth(patientCode, year, month);
@@ -28,6 +29,8 @@ public class EmotionService {
                     .collect(Collectors.toList());
         } catch (DataAccessException e) {
             throw new ApiException(ExceptionEnum.DATABASE_ERROR);
+        } catch (Exception e) {
+            throw new ApiException(ExceptionEnum.SERVER_ERROR);
         }
     }
 }


### PR DESCRIPTION
db, 서버 등등에서 타임존이 일치하지 않는 문제로 일기 조회시 입력/반환되는 문제 해결
=> createDate와 관련된 코드 모두 Date에서 String타입으로 변환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 일기 및 감정 관련 기능에서 날짜, 연도, 월 등의 파라미터 타입이 기존 Date/int에서 String으로 변경되었습니다.
  - 일기 작성 및 조회, 분석, 감정 일기 조회 시 날짜 입력 방식이 문자열(예: "yyyy-MM-dd")로 통일되었습니다.
  - 일부 컨트롤러, 서비스, DTO, 엔티티의 필드 및 메서드 시그니처가 이에 맞게 수정되었습니다.
  - 감정 컨트롤러 클래스명 및 필드명 표기 오류가 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->