### PR TITLE
fix:medicId가 반환이 안됨 수정

### DIFF
--- a/BE/src/main/java/com/oss/maeumnaru/medical/repository/MedicalRepository.java
+++ b/BE/src/main/java/com/oss/maeumnaru/medical/repository/MedicalRepository.java
@@ -4,13 +4,16 @@ import com.oss.maeumnaru.medical.entity.MedicalEntity;
 import com.oss.maeumnaru.user.entity.DoctorEntity;
 import com.oss.maeumnaru.user.entity.PatientEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface MedicalRepository extends JpaRepository<MedicalEntity, Long> {
 
-    List<MedicalEntity> findByDoctor(DoctorEntity doctor);
+    @Query("SELECT m FROM MedicalEntity m JOIN FETCH m.patient p JOIN FETCH m.doctor d WHERE m.doctor = :doctor")
+    List<MedicalEntity> findByDoctor(@Param("doctor") DoctorEntity doctor);
 
     Optional<MedicalEntity> findByPatient(PatientEntity patient);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 진료 기록 조회 시 환자 및 의사 정보가 함께 즉시 로드되어, 관련 데이터가 누락되는 문제가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->