### PR TITLE
Feat/#95 페인트 임시저장 수정

### DIFF
--- a/BE/src/main/java/com/oss/maeumnaru/global/error/exception/ExceptionEnum.java
+++ b/BE/src/main/java/com/oss/maeumnaru/global/error/exception/ExceptionEnum.java
@@ -2,6 +2,7 @@ package com.oss.maeumnaru.global.error.exception;
 
 import lombok.Getter;
 
+
 @Getter
 public enum ExceptionEnum {
     DIARY_NOT_FOUND(404, "해당 일기를 찾을 수 없습니다."),
@@ -11,6 +12,9 @@ public enum ExceptionEnum {
     SERVER_ERROR(500, "서버 내부 오류가 발생했습니다."),
     PATIENT_NOT_FOUND(404, "회원의 환자 정보가 없습니다."),
     FILE_UPLOAD_FAILED(500, "파일 업로드에 실패했습니다."),
+    FINALIZED_PAINT_CANNOT_BE_UPDATED(400, "최종 확정된 그림은 수정할 수 없습니다."),
+
+
     //명상 오류
     MEDITATION_RETRIEVAL_FAILED(500, "명상 정보를 불러오는데 실패했습니다."),
     MEDITATION_NOT_FOUND(404, "해당 명상 정보를 찾을 수 없습니다."),

--- a/BE/src/main/java/com/oss/maeumnaru/paint/controller/PaintController.java
+++ b/BE/src/main/java/com/oss/maeumnaru/paint/controller/PaintController.java
@@ -66,19 +66,28 @@ public class PaintController {
                 .orElse(ResponseEntity.notFound().build());
     }
     // 임시저장
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<PaintResponseDto> savePaintDraft(
-            Authentication authentication,
+    @PostMapping(value = "/draft", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<PaintResponseDto> saveOrUpdatePaintDraft(
+            @RequestPart(required = false) Long paintId,
             @RequestPart MultipartFile file,
-            @RequestPart PaintRequestDto dto) throws IOException {
+            @RequestPart PaintRequestDto dto,
+            Authentication authentication) throws IOException {
 
         CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
         Long memberId = principal.getMemberId();
 
         String patientCode = getPatientCodeByMemberId(memberId);
-        PaintResponseDto response = paintService.savePaintDraft(patientCode, file, dto);
-        return ResponseEntity.ok(response);
+
+        if (paintId != null) {
+            validateOwnership(paintId, memberId);
+            PaintResponseDto updatedPaint = paintService.updatePaintById(paintId, file, dto);
+            return ResponseEntity.ok(updatedPaint);
+        } else {
+            PaintResponseDto savedPaint = paintService.savePaintDraft(patientCode, file, dto);
+            return ResponseEntity.ok(savedPaint);
+        }
     }
+
 
     // 최종저장(수정사항 반영 + 대화시작 + 이후 수정불가)
     @PostMapping("/finalize")
@@ -92,26 +101,6 @@ public class PaintController {
         String patientCode = getPatientCodeByMemberId(memberId);
         paintService.finalizePaint(patientCode, file, dto);
         return ResponseEntity.ok().build();
-    }
-
-    //그림 수정
-    @PutMapping("/{paintId}")
-    public ResponseEntity<PaintResponseDto> updatePaint(
-            @PathVariable("paintId") Long id,
-            @RequestPart("file") MultipartFile file,
-            @RequestPart("paint") PaintRequestDto dto,
-            Authentication authentication) throws IOException {
-
-        // 인증된 사용자 정보는 필요하다면 검증용으로 활용 가능
-        CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
-        Long memberId = principal.getMemberId();
-
-        validateOwnership(id, memberId);
-
-        // paintId(id)를 기준으로 그림 업데이트
-        PaintResponseDto updatedPaint = paintService.updatePaintById(id, file, dto);
-
-        return ResponseEntity.ok(updatedPaint);
     }
 
     //그림 삭제

--- a/BE/src/main/java/com/oss/maeumnaru/paint/entity/PaintEntity.java
+++ b/BE/src/main/java/com/oss/maeumnaru/paint/entity/PaintEntity.java
@@ -29,5 +29,11 @@ public class PaintEntity {
     @Column(nullable = false)
     private String title;
 
+    private boolean finalized;
+    public boolean isFinalized() {
+        return this.finalized;
+    }
+
+
 
 }

--- a/BE/src/main/java/com/oss/maeumnaru/paint/service/PaintService.java
+++ b/BE/src/main/java/com/oss/maeumnaru/paint/service/PaintService.java
@@ -188,6 +188,10 @@ public class PaintService {
             PaintEntity paint = paintRepository.findById(paintId)
                     .orElseThrow(() -> new ApiException(ExceptionEnum.PAINT_NOT_FOUND));
 
+            if (paint.isFinalized()) {
+                throw new ApiException(ExceptionEnum.FINALIZED_PAINT_CANNOT_BE_UPDATED);
+            }
+
             String patientCode = paint.getPatientCode();
 
             // S3에 파일 업로드


### PR DESCRIPTION
임시저장 + 수정 병합

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 그림 초안 저장 및 수정을 하나의 엔드포인트로 통합하여, 초안 생성과 기존 초안 수정을 모두 지원합니다.
	- 그림이 최종 확정된 경우 더 이상 수정할 수 없도록 제한하는 기능이 추가되었습니다.
- **버그 수정**
	- 최종 확정된 그림을 수정하려고 할 때 사용자에게 적절한 오류 메시지가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->