### PR TITLE
fix: weekly 데이터 월요일 시작으로 변경

### DIFF
--- a/BE/src/main/java/com/oss/maeumnaru/diary/controller/DiaryAnalysisController.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/controller/DiaryAnalysisController.java
@@ -37,16 +37,42 @@ public class DiaryAnalysisController {
 
     @GetMapping("/weekly")
     public ResponseEntity<List<DiaryAnalysisResponseDto>> getWeeklyAnalysesByMemberId(
-            @RequestParam String baseDate,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") Date baseDate,
             @RequestParam String patientCode) {
 
-        List<DiaryAnalysisResponseDto> response = diaryAnalysisService.findWeeklyAnalysesByPatientCode(patientCode, baseDate)
-                .stream()
-                .map(DiaryAnalysisResponseDto::fromEntity)
-                .collect(Collectors.toList());
+        List<DiaryAnalysisEntity> entities = diaryAnalysisService.findWeeklyAnalysesByPatientCode(patientCode, baseDate);
+
+        List<DiaryAnalysisResponseDto> response = new ArrayList<>();
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(baseDate);
+
+        // 🔑 월요일부터 시작하도록 수정
+        int dayOfWeek = calendar.get(Calendar.DAY_OF_WEEK);
+        int diff = (dayOfWeek == Calendar.SUNDAY) ? -6 : (Calendar.MONDAY - dayOfWeek);
+        calendar.add(Calendar.DATE, diff);
+
+        for (int i = 0; i < 7; i++) {
+            Date currentDate = calendar.getTime();
+
+            Optional<DiaryAnalysisEntity> matchedEntity = entities.stream()
+                    .filter(entity -> isSameDay(entity.getResultDate(), currentDate))
+                    .findFirst();
+
+            if (matchedEntity.isPresent()) {
+                response.add(DiaryAnalysisResponseDto.fromEntity(matchedEntity.get()));
+            } else {
+                response.add(DiaryAnalysisResponseDto.builder()
+                        .resultDate(currentDate)
+                        .build());
+            }
+
+            calendar.add(Calendar.DATE, 1);
+        }
 
         return ResponseEntity.ok(response);
     }
+
 
     // 단일 일기 분석 결과 조회
     @GetMapping("/{diaryId}")


### PR DESCRIPTION
## weekly 데이터 월요일 시작으로 변경
환자의 일기 분석 결과 월요일을 시작으로 일주일 결과 보여주도록 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 주간 일기 분석 조회 시, 월요일부터 시작하는 7일간의 데이터를 항상 반환하도록 개선되었습니다. 데이터가 없는 날짜에는 빈 항목이 포함되어 누락 없이 일주일 전체가 표시됩니다.  
- **기능 개선**
  - 날짜 형식이 명확하게 지정되어 일기 분석 조회 요청 시 날짜 입력이 더 직관적으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->