### PR TITLE
fix:다이어리 분석 entity에 diaryId가 null로 들어가는 문제 해결

### DIFF
--- a/BE/src/main/java/com/oss/maeumnaru/diary/service/DiaryAnalysisService.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/service/DiaryAnalysisService.java
@@ -40,6 +40,7 @@ public class DiaryAnalysisService {
 
             if (existingAnalysisOpt.isPresent()) {
                 analysis = existingAnalysisOpt.get();
+                analysis.setDiary(diary);
                 analysis.setEmotionRate(request.getEmotionRate());
                 analysis.setMealCount(request.getMealCount());
                 analysis.setWakeUpTime(request.getWakeUpTime());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 기존 분석 항목을 업데이트할 때 일기와의 연결이 올바르게 갱신되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->