### PR TITLE
fix:DiaryAnalysisDTO에 creatDate추가

### DIFF
--- a/BE/src/main/java/com/oss/maeumnaru/diary/dto/DiaryAnalysisResponseDto.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/dto/DiaryAnalysisResponseDto.java
@@ -20,6 +20,7 @@ public class DiaryAnalysisResponseDto {
     private LocalTime wakeUpTime;
     private boolean wentOutside;
     private Long diaryId;  // 연관된 DiaryEntity의 ID
+    private String createDate;
 
     public static DiaryAnalysisResponseDto fromEntity(DiaryAnalysisEntity entity) {
         return DiaryAnalysisResponseDto.builder()
@@ -30,6 +31,7 @@ public class DiaryAnalysisResponseDto {
                 .wakeUpTime(entity.getWakeUpTime())
                 .wentOutside(entity.isWentOutside())
                 .diaryId(entity.getDiary() != null ? entity.getDiary().getDiaryId() : null)
+                .createDate(entity.getDiary() != null ? entity.getDiary().getCreateDate() : null)
                 .build();
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 일기 분석 응답에 생성일(createDate) 정보가 추가되어, 일기 생성일을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->