### PR TITLE
fix:patientEntity의 medical FK cascade 설정

### DIFF
--- a/BE/src/main/java/com/oss/maeumnaru/user/controller/UserController.java
+++ b/BE/src/main/java/com/oss/maeumnaru/user/controller/UserController.java
@@ -202,6 +202,10 @@ public class UserController {
             // 쿠키 삭제
             jwtTokenProvider.clearCookie(response);
 
+
+
+
+
             // 연관된 doctor 또는 patient 먼저 삭제
             if (member.getMemberType() == MemberEntity.MemberType.DOCTOR) {
                 DoctorEntity doctor = doctorRepository.findByMember_MemberId(member.getMemberId())

--- a/BE/src/main/java/com/oss/maeumnaru/user/entity/PatientEntity.java
+++ b/BE/src/main/java/com/oss/maeumnaru/user/entity/PatientEntity.java
@@ -27,7 +27,7 @@ public class PatientEntity {
     @JoinColumn(name = "member_id")  // FK 컬럼
     private MemberEntity member;
 
-    @OneToOne(fetch = FetchType.LAZY, mappedBy = "patient")
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "patient", cascade = CascadeType.ALL, orphanRemoval = true)
     private MedicalEntity medical;
 
     @OneToMany(mappedBy = "patient", cascade = CascadeType.ALL, orphanRemoval = true)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 환자 계정에서 의료 정보 삭제 시 관련 데이터가 자동으로 함께 삭제되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->