### PR TITLE
fix:user 기능 service/controller 및 예외처리 수정

### DIFF
--- a/BE/src/main/java/com/oss/maeumnaru/diary/controller/EmotionController.java
+++ b/BE/src/main/java/com/oss/maeumnaru/diary/controller/EmotionController.java
@@ -29,7 +29,7 @@ public class EmotionController {
 
         String loginId = authentication.getName();
         MemberEntity member = MemberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new ApiException(ExceptionEnum.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new ApiException(ExceptionEnum.USER_NOT_FOUND));
 
         String patientCode = member.getPatient() != null
                 ? member.getPatient().getPatientCode()

--- a/BE/src/main/java/com/oss/maeumnaru/global/error/exception/ExceptionEnum.java
+++ b/BE/src/main/java/com/oss/maeumnaru/global/error/exception/ExceptionEnum.java
@@ -2,42 +2,62 @@ package com.oss.maeumnaru.global.error.exception;
 
 import lombok.Getter;
 
-
 @Getter
 public enum ExceptionEnum {
-    DIARY_NOT_FOUND(404, "해당 일기를 찾을 수 없습니다."),
-    ANALYSIS_NOT_FOUND(404, "해당 분석 결과가 존재하지 않습니다."),
-    FORBIDDEN_ACCESS(403, "접근 권한이 없습니다."),
+
+    // 공통 오류
     INVALID_INPUT(400, "잘못된 요청입니다."),
+    FORBIDDEN_ACCESS(403, "접근 권한이 없습니다."),
     SERVER_ERROR(500, "서버 내부 오류가 발생했습니다."),
-    PATIENT_NOT_FOUND(404, "회원의 환자 정보가 없습니다."),
+    DATABASE_ERROR(500, "데이터베이스 오류가 발생했습니다."),
+
+    // Diary 관련
+    DIARY_NOT_FOUND(404, "해당 일기를 찾을 수 없습니다."),
+
+    // 분석 관련
+    ANALYSIS_NOT_FOUND(404, "해당 분석 결과가 존재하지 않습니다."),
+
+    // 파일 관련
     FILE_UPLOAD_FAILED(500, "파일 업로드에 실패했습니다."),
+    FILE_REQUIRED(400, "파일이 비어있거나 존재하지 않습니다."),
+
+    // Paint 관련
     FINALIZED_PAINT_CANNOT_BE_UPDATED(400, "최종 확정된 그림은 수정할 수 없습니다."),
+    PAINT_NOT_FOUND(404, "그림 정보를 찾을 수 없습니다."),
 
-
-    //명상 오류
+    // 명상 관련
     MEDITATION_RETRIEVAL_FAILED(500, "명상 정보를 불러오는데 실패했습니다."),
     MEDITATION_NOT_FOUND(404, "해당 명상 정보를 찾을 수 없습니다."),
     MEDITATION_SAVE_FAILED(500, "명상 정보를 저장하는 데 실패했습니다."),
     MEDITATION_DELETE_FAILED(500, "명상 정보를 삭제하는 데 실패했습니다."),
-    DATABASE_ERROR(500, "데이터베이스 오류가 발생했습니다."),
 
+    // User 관련
+    USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다."),
+    DOCTOR_NOT_FOUND(404, "의사 정보를 찾을 수 없습니다."),
+    PATIENT_NOT_FOUND(404, "환자 정보를 찾을 수 없습니다."),
 
-    // ✅ [User 관련 예외 추가]
-    MEMBER_NOT_FOUND(404, "해당 회원을 찾을 수 없습니다."),
     DUPLICATE_LOGIN_ID(409, "이미 사용 중인 로그인 ID입니다."),
+    DUPLICATE_EMAIL(409, "이미 사용 중인 이메일입니다."),
+
     INVALID_PASSWORD(401, "비밀번호가 일치하지 않습니다."),
-    MISSING_LICENSE_NUMBER(400, "의사의 면허번호는 필수입니다."),
-    S3_UPLOAD_FAILED(500, "파일 업로드 중 오류가 발생했습니다."),
-    AUTHENTICATION_FAILED(401, "로그인 인증에 실패했습니다."),
-    MEDICAL_NOT_FOUND(404, "의료 기록을 찾을 수 없습니다."),
-    DOCTOR_NOT_FOUND(404, "해당 의사를 찾을 수 없습니다."),
-    PATIENT_ALREADY_ASSIGNED(409, "해당 환자는 이미 다른 의사에게 배정되어 있습니다."),
+    INVALID_TOKEN(401, "유효하지 않은 토큰입니다."),
 
+    MISSING_LICENSE_NUMBER(400, "의사의 licenseNumber는 필수입니다."),
+    INVALID_MEMBER_TYPE(400, "유효하지 않은 사용자 유형입니다."),
 
-    PAINT_NOT_FOUND(404, "해당 의사를 찾을 수 없습니다."),
+    // User 서비스 처리 실패
+    SIGNUP_FAILED(500, "회원가입 처리 중 오류가 발생했습니다."),
+    LOGIN_FAILED(401, "로그인 처리 중 오류가 발생했습니다."),
+    ACCOUNT_WITHDRAWAL_FAILED(500, "회원 탈퇴 처리 중 오류가 발생했습니다."),
+
+    // Medical 관련
+    MEDICAL_NOT_FOUND(404, "해당 진료 기록을 찾을 수 없습니다."),
+    PATIENT_ALREADY_ASSIGNED(409, "환자가 이미 다른 의사에게 배정되어 있습니다."),
+
+    // 채팅 관련
     CHAT_ALREADY_COMPLETED(409, "이미 완료된 대화입니다."),
-    CHAT_ALREADY_START(404, "채팅이 이미 시작되었습니다." );
+    CHAT_ALREADY_START(409, "채팅이 이미 시작되었습니다.");
+
     private final int status;
     private final String message;
 
@@ -46,6 +66,11 @@ public enum ExceptionEnum {
         this.message = message;
     }
 
-    public int getStatus() { return status; }
-    public String getMessage() { return message; }
+    public int getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
 }

--- a/BE/src/main/java/com/oss/maeumnaru/paint/service/PaintService.java
+++ b/BE/src/main/java/com/oss/maeumnaru/paint/service/PaintService.java
@@ -92,7 +92,7 @@ public class PaintService {
 
         } catch (IOException e) {
             // 파일 업로드 중 오류가 발생하면 예외 처리
-            throw new ApiException(ExceptionEnum.S3_UPLOAD_FAILED);
+            throw new ApiException(ExceptionEnum.FILE_UPLOAD_FAILED);
         } catch (Exception e) {
             // 그 외 예기치 않은 예외 처리
             throw new ApiException(ExceptionEnum.SERVER_ERROR);

--- a/BE/src/main/java/com/oss/maeumnaru/user/controller/UserController.java
+++ b/BE/src/main/java/com/oss/maeumnaru/user/controller/UserController.java
@@ -84,85 +84,16 @@ public class UserController {
     // 마이페이지 - 내 정보 조회
     @GetMapping("/me")
     public ResponseEntity<UserProfileResponseDTO> getMyInfo(Authentication authentication) {
-        System.out.println("authentication = " + authentication);
-        System.out.println("authentication.getPrincipal() = " + authentication.getPrincipal());
-        System.out.println("authentication.getName() = " + authentication.getName());
-
-        String loginId = authentication.getName();
-
-        MemberEntity member = memberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다."));
-
-        String hospital = null;
-        String patientCode = null;  // 기본 null
-
-        if (member.getMemberType() == MemberEntity.MemberType.DOCTOR) {
-            // 환자 병원명 조회
-            hospital = doctorRepository.findByMember_MemberId(member.getMemberId())
-                    .map(DoctorEntity::getHospital)
-                    .orElse(null);
-
-        } else if (member.getMemberType() == MemberEntity.MemberType.PATIENT) {
-            hospital = patientRepository.findByMember_MemberId(member.getMemberId())
-                    .map(PatientEntity::getPatientHospital)
-                    .orElse(null);
-            // 환자코드 조회
-            patientCode = patientRepository.findByMember_MemberId(member.getMemberId())
-                    .map(PatientEntity::getPatientCode)
-                    .orElse(null);
-        }
-
-        UserProfileResponseDTO response = UserProfileResponseDTO.builder()
-                .memberId(member.getMemberId())
-                .name(member.getName())
-                .loginId(member.getLoginId())
-                .email(member.getEmail())
-                .phone(member.getPhone())
-                .gender(String.valueOf(member.getGender()))
-                .memberType(member.getMemberType().name())
-                .birthDate(member.getBirthDate() != null ? member.getBirthDate().toString() : null)
-                .createDate(member.getCreateDate() != null ? member.getCreateDate().toString() : null)
-                .hospital(hospital)
-                .patientCode(patientCode)
-                .build();
-
+        UserProfileResponseDTO response = userService.getMyInfo(authentication.getName());
         return ResponseEntity.ok(response);
     }
 
-
+    // 마이페이지 - 내 정보 수정
     @PutMapping("/me")
     public ResponseEntity<Void> updateMyInfo(
             @RequestBody UserUpdateRequestDTO dto,
             Authentication authentication) {
-
-        String loginId = authentication.getName();
-        MemberEntity member = memberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자 없음"));
-
-        if (dto.getEmail() != null) member.setEmail(dto.getEmail());
-
-        if (dto.getPassword() != null) {
-            // 🔒 비밀번호 암호화 후 저장
-            member.setPassword(passwordEncoder.encode(dto.getPassword()));
-        }
-
-        if (dto.getPhone() != null) member.setPhone(dto.getPhone());
-
-        if (dto.getHospital() != null) {
-            if (member.getMemberType() == MemberEntity.MemberType.DOCTOR) {
-                doctorRepository.findByMember_MemberId(member.getMemberId()).ifPresent(doctor -> {
-                    doctor.setHospital(dto.getHospital());
-                    doctorRepository.save(doctor);
-                });
-            } else if (member.getMemberType() == MemberEntity.MemberType.PATIENT) {
-                patientRepository.findByMember_MemberId(member.getMemberId()).ifPresent(patient -> {
-                    patient.setPatientHospital(dto.getHospital());
-                    patientRepository.save(patient);
-                });
-            }
-        }
-
-        memberRepository.save(member);
+        userService.updateMyInfo(authentication.getName(), dto);
         return ResponseEntity.ok().build();
     }
 
@@ -170,56 +101,7 @@ public class UserController {
     // 회원 탈퇴 (Redis 삭제 + 쿠키 삭제 + DB 삭제)
     @DeleteMapping("/me")
     public ResponseEntity<Void> withdrawMyAccount(Authentication authentication, HttpServletResponse response) {
-        String loginId = authentication.getName();
-        MemberEntity member = memberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자 없음"));
-        String memberType = String.valueOf(member.getMemberType());  // DOCTOR 또는 PATIENT
-
-        if ("DOCTOR".equalsIgnoreCase(memberType)) {
-            DoctorEntity doctor = doctorRepository.findByMember_MemberId(member.getMemberId())
-                    .orElseThrow(() -> new RuntimeException("의사 정보가 없습니다."));
-            String licenseNumber = doctor.getLicenseNumber();
-
-            // 예: S3에서 의사 면허증 파일 경로
-            String folderPrefix = "doctor/" + licenseNumber + "/";
-
-            s3Service.deleteFolder(folderPrefix);
-
-
-        }
-        else if ("PATIENT".equalsIgnoreCase(memberType)) {
-            PatientEntity patient = patientRepository.findByMember_MemberId(member.getMemberId())
-                    .orElseThrow(() -> new RuntimeException("환자 정보가 없습니다."));
-            String patientCode = patient.getPatientCode();
-            // 예: S3에서 의사 면허증 파일 경로
-            String folderPrefix = "patient/" + patientCode + "/";
-
-            s3Service.deleteFolder(folderPrefix);
-            // Redis 토큰 삭제
-            //
-            tokenRedisRepository.deleteById(String.valueOf(member.getMemberId()));
-
-            // 쿠키 삭제
-            jwtTokenProvider.clearCookie(response);
-
-
-
-
-
-            // 연관된 doctor 또는 patient 먼저 삭제
-            if (member.getMemberType() == MemberEntity.MemberType.DOCTOR) {
-                DoctorEntity doctor = doctorRepository.findByMember_MemberId(member.getMemberId())
-                        .orElseThrow(() -> new RuntimeException("해당 의사를 찾을 수 없습니다."));
-                if (doctor.getCertificationPath() != null) {
-                    s3Service.deleteFile(doctor.getCertificationPath());
-                }
-                doctorRepository.delete(doctor);
-            } else if (member.getMemberType() == MemberEntity.MemberType.PATIENT) {
-                patientRepository.delete(patient);
-            }
-            memberRepository.delete(member);
-            return ResponseEntity.ok().build();
-        }
+        userService.withdrawMyAccount(authentication.getName(), response);
         return ResponseEntity.ok().build();
     }
 }


### PR DESCRIPTION
fix:user 기능 service/controller 로직 분리(리펙토링) 및 ExceptionEnum 재분류 및 user 관련 내용 추가 후 반영

1. 마이페이지 및 회원 탈퇴 부분 controller에 잘못 포함되어있던 로직 service로 다시 옮김
     -> 컨트롤러: 복잡한 로직 제거 → Service 호출만 남김 -> 예외 처리 방식 통일
2. ExceptionEnum에서 기능별 분류되어있던 내용 공통부분 따로 분리
3. User 기능 관련 예외처리 로직 통일(service, contoller) 및 ExceptionEnum 추가
